### PR TITLE
sqlfluff 3.0.7 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sqlfluff" %}
-{% set version = "1.4.5" %}
+{% set version = "3.0.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,37 +7,36 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sqlfluff-{{ version }}.tar.gz
-  sha256: 68a8abde2fa22b76a20d908e22087e2e12b0e4a2085be2ea955ff6305b0fea30
+  sha256: d49b52c4577ce113ef6318a933c7a7fedd25852dea5e9fe0981cf301c6b73927
 
 build:
-  noarch: python
   number: 0
   entry_points:
     - sqlfluff = sqlfluff.cli.commands:cli
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv 
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - wheel
+    - setuptools >=40.8.0
   run:
     - appdirs
-    - backports.cached-property
     - chardet
     - click
     - colorama >=0.3
     - diff-cover >=2.5.0
-    - importlib_metadata >=1.0.0
+    - importlib-resources   # [py<39]
     - jinja2
     - pathspec
     - pytest
-    - python >=3.7
+    - python
     - pyyaml >=5.1
     - regex
     - tblib
-    - toml
+    - toml   # [py<311]
     - tqdm
-    - typing_extensions
 
 test:
   source_files:
@@ -58,6 +57,7 @@ about:
   dev_url: https://github.com/sqlfluff/sqlfluff
   doc_url: https://docs.sqlfluff.com/en/stable/index.html
   license: MIT
+  license_family: MIT
   license_file: LICENSE.md
   description: |
     SQLFluff is a dialect-flexible and configurable SQL linter. Designed


### PR DESCRIPTION
sqlfluff 3.0.7 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4761]
- dev_url:        https://github.com/sqlfluff/sqlfluff/tree/3.0.7
- conda_forge:    https://github.com/conda-forge/sqlfluff-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/sqlfluff/3.0.7
- pypi inspector: https://inspector.pypi.io/project/sqlfluff/3.0.7

### Explanation of changes:

- new version number


[PKG-4761]: https://anaconda.atlassian.net/browse/PKG-4761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ