### PR TITLE
sqlfluff 4.1.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
 upload_channels:
   - sfe1ed40
 
+channels:
+  - https://staging.continuum.io/pbp/fs/diff-cover-feedstock/pr3/9aa2b16

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/pbp/fs/diff-cover-feedstock/pr3/9aa2b16

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ build:
     - sqlfluff = sqlfluff.cli.commands:cli
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<39]
+  # No diff-cover >2.5 for py>312
+  skip: true  # [py>312]
 
 requirements:
   host:
@@ -37,6 +39,9 @@ requirements:
     - tblib
     - toml   # [py<311]
     - tqdm
+
+# Error: fixture 'test_verbosity_level' not found
+{% set deselect_tests = " --deselect=test/testing_test.py::test_rules_test_case_has_variable_introspection" %}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,20 @@
 {% set name = "sqlfluff" %}
-{% set version = "3.0.7" %}
+{% set version = "4.1.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sqlfluff-{{ version }}.tar.gz
-  sha256: d49b52c4577ce113ef6318a933c7a7fedd25852dea5e9fe0981cf301c6b73927
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/sqlfluff-{{ version }}.tar.gz
+  sha256: 83dd4c081afb48c0af861833015a18b13d52726bfe52a286246dbd7a64b7d111
 
 build:
   number: 0
   entry_points:
     - sqlfluff = sqlfluff.cli.commands:cli
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv 
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -22,16 +23,15 @@ requirements:
     - wheel
     - setuptools >=40.8.0
   run:
-    - appdirs
+    - python
+    - platformdirs
     - chardet
-    - click
+    - click <8.4.0
     - colorama >=0.3
     - diff-cover >=2.5.0
-    - importlib-resources   # [py<39]
-    - jinja2
+    - jinja2  
     - pathspec
     - pytest
-    - python
     - pyyaml >=5.1
     - regex
     - tblib
@@ -46,13 +46,13 @@ test:
   commands:
     - pip check
     - sqlfluff --help
-    - pytest -vvv --capture=tee-sys -k "not test_helper_has_variable_introspection" test
+    - pytest -vvv test
   requires:
     - pip
     - pytest
 
 about:
-  home: https://www.sqlfluff.com/
+  home: https://www.sqlfluff.com
   summary: The SQL Linter for Humans
   dev_url: https://github.com/sqlfluff/sqlfluff
   doc_url: https://docs.sqlfluff.com/en/stable/index.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ test:
   commands:
     - pip check
     - sqlfluff --help
-    - pytest -vvv test
+    - pytest -vvv test {{ deselect_tests }}
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,6 @@ build:
     - sqlfluff = sqlfluff.cli.commands:cli
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<39]
-  # No diff-cover >2.5 for py>312
-  skip: true  # [py>312]
 
 requirements:
   host:


### PR DESCRIPTION
sqlfluff 4.1.0 

**Destination channel:** Defaults

### Links

- [PKG-13453]
- dev_url:        https://github.com/sqlfluff/sqlfluff/tree/4.1.0
- conda_forge:    https://github.com/conda-forge/sqlfluff-feedstock
- pypi:           https://pypi.org/project/sqlfluff/4.1.0
- pypi inspector: https://inspector.pypi.io/project/sqlfluff/4.1.0

### Explanation of changes:

- new version number


[PKG-13453]: https://anaconda.atlassian.net/browse/PKG-13453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ