### PR TITLE
sqlfluff 4.2.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/sqlfluff-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 0ee2bcd5d704d0bef56bf80b8f0da9b519ab3e9e0bb1d5e6e4b7e3944d3f5606
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - sqlfluff = sqlfluff.cli.commands:cli
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<39]
+  skip: true  # [py<31-]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,9 @@ requirements:
     - tblib
     - toml   # [py<311]
     - tqdm
+  run_constrained:
+    # rs
+    - sqlfluffrs ==4.2.2
 
 # Error: fixture 'test_verbosity_level' not found
 {% set deselect_tests = " --deselect=test/testing_test.py::test_rules_test_case_has_variable_introspection" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   entry_points:
     - sqlfluff = sqlfluff.cli.commands:cli
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<31-]
+  skip: true  # [py<310]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,8 @@ requirements:
     - click <8.4.0
     - colorama >=0.3
     - diff-cover >=2.5.0
-    - jinja2  
+    - jinja2
     - pathspec
-    - pytest
     - pyyaml >=5.1
     - regex
     - tblib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sqlfluff" %}
-{% set version = "4.1.0" %}
+{% set version = "4.2.2" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/sqlfluff-{{ version }}.tar.gz
-  sha256: 83dd4c081afb48c0af861833015a18b13d52726bfe52a286246dbd7a64b7d111
+  sha256: 0ee2bcd5d704d0bef56bf80b8f0da9b519ab3e9e0bb1d5e6e4b7e3944d3f5606
 
 build:
   number: 0


### PR DESCRIPTION
sqlfluff 4.2.2 

**Destination channel:** Defaults

### Links

- [PKG-16654]
- dev_url:        https://github.com/sqlfluff/sqlfluff
- conda_forge:    https://github.com/conda-forge/sqlfluff-feedstock
- pypi:           https://pypi.org/project/sqlfluff/4.2.2
- pypi inspector: https://inspector.pypi.io/project/sqlfluff/4.2.2

### Explanation of changes:

- new version number


[PKG-16654]: https://anaconda.atlassian.net/browse/PKG-16654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ